### PR TITLE
Added Roles table, fixed step definitions

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Guardfile
+++ b/Guardfile
@@ -69,8 +69,8 @@ guard :rspec, cmd: "bundle exec spring rspec" do
   end
 
   # User & Project watching
-  watch(%r{^app/models/(user|project)\.rb}) { "#{rspec.spec_dir}/association_spec.rb" }
-
+  watch(%r{^app/models/.+\.rb}) { "#{rspec.spec_dir}/association_spec.rb" }
+  
 
   
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -24,6 +24,7 @@ class ProjectsController < ApplicationController
 	def create
 		@project = Project.new(project_params)
 		if @project.save
+                        @project.managers << current_user
 			redirect_to @project, notice: "Successfully created project."
 		else
 			render :new

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -31,7 +31,7 @@ class Ability
 
      user ||= User.new # guest user (not logged in)
       # manager abilities
-      if user.role == "manager"
+      if user.manager
         can :manage, Project
         can :read, :all
       end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,3 @@
+class Role < ActiveRecord::Base
+  belongs_to :users
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   has_and_belongs_to_many :skills
+  has_one :role
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -26,11 +27,12 @@ class User < ActiveRecord::Base
       end
     end
   end
-
+  
   def demote_manager_all
     my_projects = self.manages.to_a
     self.manages.delete_all
     self.projects << my_projects
+    self.manager = false
   end
   
   private :manager_relationships, :manager_relationships=

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,18 @@ class User < ActiveRecord::Base
     self.projects << my_projects
     self.manager = false
   end
+
+  def name
+    if self.first_name.nil? && self.last_name.nil?
+      return ""
+    elsif !self.first_name.nil? && self.last_name.nil?
+      return self.first_name
+    elsif self.first_name.nil? && !self.last_name.nil?
+      return self.last_name
+    else
+      return self.first_name + " " + self.last_name
+    end
+  end
   
   private :manager_relationships, :manager_relationships=
   private :volunteer_relationships, :volunteer_relationships=

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -62,14 +62,14 @@
 		<%= @project.location %>
 	</div>
 	<div class="col-md-12">
-		<p> <strong>Project</strong> <%= @project.name %> Has <strong><%= @project.volunteers.count %></strong> volunteers, needs <strong><%= @project.volunteer_capacity - @project.volunteers.count %></strong> more!</p>
+		<p> <strong>Project</strong> <%= @project.name %> has <strong><%= @project.volunteers.count %></strong> volunteers, needs <strong><%= @project.volunteer_capacity - @project.volunteers.count %></strong> more!</p>
 	</div>
 	<div class="col-md-12">
 		<%if @project.managers.count == 0 || @project.managers == "" %>
 			<p><strong>Project Manager: ---- </strong></p>
 			<p><strong>Manager Contact Information: ---- </strong></p>
 		<% else %>
-			<p> <strong>Project Manager: </strong><%= @project.managers.first.first_name %></p>
+			<p> <strong>Project Manager: </strong><%= @project.managers.first.name %></p>
 			<p> <strong>Manager Contact Information: </strong> <%=@project.managers.first.email %></p>
 		<% end %>
 	</div>

--- a/db/migrate/20170719173220_create_role_table.rb
+++ b/db/migrate/20170719173220_create_role_table.rb
@@ -1,0 +1,12 @@
+class CreateRoleTable < ActiveRecord::Migration
+  def change
+    create_table :roles do |t|
+      t.belongs_to :user, index: true
+      t.string :name, default: nil
+    end
+
+    remove_column :users, :role
+    add_foreign_key :users, :roles
+    
+  end
+end

--- a/db/migrate/20170719181224_add_unique_index_on_roles.rb
+++ b/db/migrate/20170719181224_add_unique_index_on_roles.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnRoles < ActiveRecord::Migration
+  def change
+    add_index :roles, :name, unique: true
+  end
+end

--- a/db/migrate/20170719183402_remove_role_from_volunteer_relationship.rb
+++ b/db/migrate/20170719183402_remove_role_from_volunteer_relationship.rb
@@ -1,0 +1,5 @@
+class RemoveRoleFromVolunteerRelationship < ActiveRecord::Migration
+  def change
+    remove_column :volunteer_relationships, :role, type: :string
+  end
+end

--- a/db/migrate/20170719184113_add_admin_bool_to_users.rb
+++ b/db/migrate/20170719184113_add_admin_bool_to_users.rb
@@ -1,0 +1,6 @@
+class AddAdminBoolToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :admin, :boolean, {default: false}
+    add_column :users, :manager, :boolean, {default: false}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170715215531) do
+ActiveRecord::Schema.define(version: 20170719184113) do
 
   create_table "manager_relationships", force: :cascade do |t|
     t.integer "user_id"
@@ -37,6 +37,14 @@ ActiveRecord::Schema.define(version: 20170715215531) do
     t.integer  "hours_per_week"
     t.integer  "manager_id"
   end
+
+  create_table "roles", force: :cascade do |t|
+    t.integer "user_id"
+    t.string  "name"
+  end
+
+  add_index "roles", ["name"], name: "index_roles_on_name", unique: true
+  add_index "roles", ["user_id"], name: "index_roles_on_user_id"
 
   create_table "skills", force: :cascade do |t|
     t.integer  "user_id"
@@ -75,7 +83,6 @@ ActiveRecord::Schema.define(version: 20170715215531) do
     t.string   "school"
     t.string   "availability"
     t.boolean  "complete",               default: false
-    t.string   "role"
     t.string   "phone"
     t.integer  "zip"
     t.string   "location"
@@ -94,6 +101,8 @@ ActiveRecord::Schema.define(version: 20170715215531) do
     t.string   "availability_comments"
     t.string   "certifications"
     t.string   "travel"
+    t.boolean  "admin",                  default: false
+    t.boolean  "manager",                default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true
@@ -102,7 +111,6 @@ ActiveRecord::Schema.define(version: 20170715215531) do
   create_table "volunteer_relationships", force: :cascade do |t|
     t.integer "user_id"
     t.integer "project_id"
-    t.string  "role"
   end
 
   add_index "volunteer_relationships", ["project_id"], name: "index_volunteer_relationships_on_project_id"

--- a/features/manage_projects.feature
+++ b/features/manage_projects.feature
@@ -11,7 +11,7 @@ Background:
 
 Scenario: Creating and Updating a Project
   Given I am on the projects page
-  When I follow "New Project"
+  When I follow "Create New Project"
   Then I should be on the new project page
   And I fill in "Name" with "Remove Snakes From Boots"
   And I fill in "Description" with "Assist toy cowboys with recurring problem."

--- a/features/step_definitions/ewb_steps.rb
+++ b/features/step_definitions/ewb_steps.rb
@@ -3,7 +3,7 @@ Given /^I am not authenticated$/ do
 end
 
 Given /^I am a new, authenticated user$/ do
-  email = 'testing@man.net'
+  email = 'testing@user.net'
   password = 'secretpass'
   User.new(:email => email, :password => password, :password_confirmation => password).save!
 
@@ -13,17 +13,34 @@ Given /^I am a new, authenticated user$/ do
   click_button "Log in"
 end
 
-Given /^I am a project manager$/ do
-  email = 'testing@man.net'
-  password = 'secretpass'
-  role = 'manager'
-  User.new(:email => email, :password => password, :role => role).save!
+Given /^I am a project manager on "(.+)"/ do |project_name|
+  manager = User.create(email: 'testing@man.net', password: "asdfghjkl", manager: true)
+  if(!Project.exists?(name: project_name))
+    Project.create(name: project_name,
+                   description: "Creating a large-scale water filter system",
+                   volunteer_capacity: 25, location: "Remba Island, Kenya")
+  end
+  project = Project.find_by name: project_name
+  project.managers << manager
 
   visit new_user_session_path
   fill_in "user_email", :with => email
   fill_in "user_password", :with => password
   click_button "Log in"
 end
+
+
+Given /^I am a project manager$/ do
+  email = 'testing@man.net'
+  password = 'secretpass'
+  User.create(:email => email, :password => password, :manager => true)
+
+  visit new_user_session_path
+  fill_in "user_email", :with => email
+  fill_in "user_password", :with => password
+  click_button "Log in"
+end
+
 
 Given /^the following users exist:$/ do |table|
 	table.hashes.each do |table_hash|
@@ -32,6 +49,24 @@ Given /^the following users exist:$/ do |table|
 				 :first_name => table_hash[:first_name],
 				 :last_name => table_hash[:last_name]).save!
 	end
+end
+
+When /^I follow the project link for "(.+)"$/ do |project_name|
+  click_link(project_name)
+end
+
+
+Given /^there exists a project "([^"]*)"$/ do |arg1|
+  test_project = Project.create(name: arg1,
+                                description: "Creating a large-scale water filter system", 
+                                volunteer_capacity: 25,
+                                location: "Remba Island, Kenya")
+  test_project_manager = User.create(first_name: "Luke",
+                                     last_name: "Skywalker",
+                                     email: 'testing@man.net',
+                                     password: "asdfghjkl",
+                                     manager: true)
+  test_project.managers << test_project_manager
 end
 
 # Then(/^I should see "([^"]*)" before "([^"]*)"$/) do |arg1, arg2|
@@ -58,14 +93,3 @@ end
 #   # table is a Cucumber::MultilineArgument::DataTable
 #   pending # Write code here that turns the phrase above into concrete actions
 # end
-
-# When(/^I follow a Project Link$/) do
-#   pending # Write code here that turns the phrase above into concrete actions
-# end
-
-
-Given(/^there exists a project "([^"]*)"$/) do |arg1|
-  test_project = Project.new(name: arg1, description: "Creating a large-scale water filter system", 
-  volunteer_capacity: 25, location: "Remba Island, Kenya")
-  test_project.save!
-end

--- a/features/view_project_info.feature
+++ b/features/view_project_info.feature
@@ -2,14 +2,14 @@ Feature: Viewing Project Information
   As a volunteer for Engineers Without Borders
   I should be able to view information about various projects
   So that I can choose projects to apply for
-  
+
   Scenario: Clicking on a Project Listing
     Given I am a new, authenticated user
+    Given there exists a project "Remba Island Project"
     Given I am on the projects page
-    When I follow a Project Link
-    Then I should see "Project Description"
-    And I should see "Project Dates"
-    And I should see "Project Location"
-    And I should see "Project Manager"
-    And I should see "Manager Contact Information"
-    And I should see "Current Volunteers"
+    When I follow the project link for "Remba Island Project"
+    Then I should see "Creating a large-scale water filter system"
+    And I should see "Remba Island, Kenya"
+    And I should see "Luke Skywalker"
+    And I should see "testing@man.net"
+    And I should see "Project has 0 volunteers, needs 25 more!"

--- a/features/volunteer_register.feature
+++ b/features/volunteer_register.feature
@@ -5,8 +5,8 @@ Feature: User Registration
 
 Scenario: Filling out the Volunteer Form by subscribing
   Given I am on the home page
-  Then I should see "Sign up now!"
-  When I follow "Sign up now!"
+  Then I should see "GET INVOLVED"
+  When I follow "GET INVOLVED"
   When I fill in "Email" with "woody@andysroom.com"
   And I fill in "user_password" with "reachforthesky"
   And I fill in "user_password_confirmation" with "reachforthesky"

--- a/spec/association_spec.rb
+++ b/spec/association_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 # User associations: Project (as Volunteer through VolunteerRelationship), Roles (has_one), Skills (HABTM), Certifications (HABTM), Experience (HABTM)
 
 RSpec.describe User, :type => :model do
-  before(:each) do
-    @example_user = FactoryGirl.create(:user, password: "asdfghjkl")
-    @example_project = FactoryGirl.create(:project)
-  end
   describe "As a volunteer" do
+    before(:each) do
+      @example_user = FactoryGirl.create(:user, password: "asdfghjkl")
+      @example_project = FactoryGirl.create(:project)
+    end
     it "Has a valid factory" do
       expect(@example_user).to be_valid
       expect(@example_project).to be_valid
@@ -29,15 +29,11 @@ RSpec.describe User, :type => :model do
       expect(@example_user.projects.count).to eq 0
     end
   end
-  # Add role, skill, experience tests here
-end
-
-RSpec.describe User, :type => :model do
-  before(:each) do
-    @example_manager = FactoryGirl.create(:manager, password: "asdfghjkl")
-    @example_project = FactoryGirl.create(:project)
-  end
   describe "As a manager" do
+    before(:each) do
+      @example_manager = FactoryGirl.create(:manager, password: "asdfghjkl")
+      @example_project = FactoryGirl.create(:project)
+    end
     it "Has a valid factory" do
       expect(@example_manager).to be_valid
       expect(@example_project).to be_valid
@@ -71,6 +67,8 @@ RSpec.describe User, :type => :model do
       expect(@example_manager.projects.count).to eq 2
       expect(@example_project.managers.count).to eq 0
       expect(@example_project2.managers.count).to eq 0
+      # Manager loses manager privileges
+      expect(@example_manager.manager).to be false
     end
     it "Adding as volunteer when already manager" do
       @example_manager.manages << @example_project
@@ -93,6 +91,34 @@ RSpec.describe User, :type => :model do
       @example_manager.manages << @example_project
       @example_project.destroy
       expect(@example_manager.manages.count).to eq 0
+    end
+  end
+  # Add role, skill, experience tests here
+  describe "User roles" do
+    before(:each) do
+      @example_user = FactoryGirl.create(:user, password: "asdfghjkl")
+      @example_role = FactoryGirl.create(:role, name: "Programmer")
+    end
+    it "Adding role column to user" do
+      expect(@example_user.role).to be_nil
+    end
+    it "Get role name" do
+      @example_user.role = @example_role
+      expect(@example_user.role.name).to match "Programmer"
+    end
+    it "No duplicate roles" do
+      expect{
+        @example_role2 = FactoryGirl.create(:role, name: "Programmer")
+      }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+    it "Build role off user" do
+      @example_user.create_role(name: "Cook")
+      expect(@example_user.role.name).to match "Cook"
+    end
+    it "Role stays in table if user is deleted" do
+      @example_user.role = @example_role
+      @example_user.destroy
+      expect(Role.all.count).to eq 1
     end
   end
 end

--- a/spec/factories/role_factory.rb
+++ b/spec/factories/role_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :role do
+    name { Faker::Job.title } 
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -7,7 +7,6 @@ FactoryGirl.define do
         sign_in_count 1
         created_at { 10.years.ago }
         updated_at { 10.years.ago }
-        role "volunteer"
     end
     factory :manager, class: User do
         first_name { Faker::Name.first_name }
@@ -17,6 +16,6 @@ FactoryGirl.define do
         sign_in_count 1
         created_at { 10.years.ago }
         updated_at { 10.years.ago }
-        role "manager"
+        manager true
     end
 end


### PR DESCRIPTION
Added Roles table and undid db changes that Adolfo didn't want. Added some step definitions to better define project managers on example projects. Updated user stories to reflect the new button text. Changed the "role" column on Users, it now points to the user-defined "Role" that they select when they sign up. Added "manager" column to Users as a bool. Also added "admin" column to Users as a bool. When Managers now create a project, they are automatically added as the Project Manager. 