### PR TITLE
Maint: fix bug which deletes current image if profile updated but not…

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -362,7 +362,9 @@ class UsersController < ApplicationController
       user.design_experiences = DesignExperience.find(params[:des_exp]).to_a
     end
     
-    user.update_attribute(:avatar, params[:user][:avatar])
+    unless params[:user][:avatar].nil?
+      user.update_attribute(:avatar, params[:user][:avatar])
+    end
     
     user.save
     


### PR DESCRIPTION
Solve bug which updates avatar to null if you don't upload a new image on profile update.